### PR TITLE
Pacakge restructuring

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -195,31 +195,44 @@ Create a new project for Chainsight Platform.
 This generated project contains several Manifests as templates.  
 Specify the name of the project to be created, and then generate the project.
 
-```bash
-csx new sample_project
+```txt
+csx new --help  
+Generates Chainsight project with built-in templates
+
+Usage: csx new [OPTIONS] <PROJECT_NAME>
+
+Arguments:
+  <PROJECT_NAME>  Specifies the name of the project to create
+
+Options:
+      --no-samples  Skip generation of sample component manifests [short aliases: n]
+  -v, --verbose...  Displays detailed information about operations. -vv will generate a very large number of messages and can
+                    affect performance
+  -q, --quiet...    Suppresses informational messages. -qq limits to errors only; -qqqq disables them all
+  -h, --help        Print help
 ```
 
-## csx create
+## csx add
 
-The 'create' command is used to add a new type of component to your project.
+The 'add' command is used to add a new type of component to your project.
 
 This command will add a Component Manifest of the specified Type and its management settings to the Project Manifest.
 
 If you are familiar with it, you can do manually what this command does.
 
 ```txt
-% csx create --help
+% csx add --help
 Generates component manifest of specified type and adds to your project
 
-Usage: csx create [OPTIONS] --type <TYPE> <COMPONENT_NAME>
+Usage: csx add [OPTIONS] --type <TYPE> <COMPONENT_NAME>
 
 Arguments:
   <COMPONENT_NAME>
-          Specifies the name of the component to create
+          Specifies the name of the component to add
 
 Options:
       --type <TYPE>
-          Specifies type of the component to create
+          Specifies type of the component to add
 
           Possible values:
           - event-indexer:          To synchronize event data
@@ -247,34 +260,35 @@ Options:
 - `--path`: Select the path of the project to which you want to add the Component.
   - The folder containing the `.chainsight` file will be recognized as the project.
 
-## csx build
+## csx generate
 
-Performs everything from code generation to compilation of the Module to deploy from Manifest to Canister.
+```txt
+% csx generate --help (or csx gen ...)
+Generate codes according to project/component manifests
 
-You must specify the project path to build and execute this command.
+Usage: csx generate [OPTIONS]
 
-```bash
-csx build --path sample_project
+Options:
+      --path <PATH>  Specify the path of the project. If not specified, the current directory is targeted
+  -v, --verbose...   Displays detailed information about operations. -vv will generate a very large number of messages and can affect performance
+  -q, --quiet...     Suppresses informational messages. -qq limits to errors only; -qqqq disables them all
+  -h, --help         Print help
 ```
 
-> **Note** For developers who want more control  
-> (The specifications are still under review and subject to change.) The command is divided into two phases: codegen and build. The developer can pass a flag to execute only one of them.  
-> `--only-codegen`: Perform code generation only  
-> `--only-build`: Perform build only (from already generated code)`
+## csx build
 
 ```txt
 % csx build --help 
-Builds your project to generate canisters' modules for Chainsight
+BBuilds your project to generate canisters' modules for Chainsight
 
 Usage: csx build [OPTIONS]
 
 Options:
-      --path <PATH>   Specify the path of the project to be built. If not specified, the current directory is targeted
-  -v, --verbose...    Displays detailed information about operations. -vv will generate a very large number of messages and can affect performance
-      --only-codegen  Only perform code generation
-  -q, --quiet...      Suppresses informational messages. -qq limits to errors only; -qqqq disables them all
-      --only-build    Only perform build. Perform this steps with code already generated
-  -h, --help          Print help
+      --path <PATH>  Specify the path of the project to build. If not specified, the current directory is targeted
+  -v, --verbose...   Displays detailed information about operations. -vv will generate a very large number of messages and can affect performance
+      --only-build   Only perform build. Perform this steps with code already generated
+  -q, --quiet...     Suppresses informational messages. -qq limits to errors only; -qqqq disables them all
+  -h, --help         Print help
 ```
 
 ## csx deploy
@@ -283,10 +297,7 @@ This command is used to deploy a built module of your own Project to a specified
 
 It is built by wrapping the operations performed by the dfx deploy command, plus Identity and Wallet checks.
 
-- `--path`: Specify the path where the built artifacts are located.
-  - Build artifacts are located in `/artifacts` under the project folder.
-  - ex: If the project folder is `./sample_project`, the build artifacts will be located in `./sample_project/artifacts`.
-    - In that case, the command is `dfx deploy -path sample_project/artifacts`.
+- `--path`: Specify the path of the project to deploy. If not specified, the current directory is targeted
 - `--network`: Specify the network to deploy to.
   - Currently, you can choose between the following options.
     - local ... localhost
@@ -299,7 +310,7 @@ Deploy the components of your project. If you want to operate on a local network
 Usage: csx deploy [OPTIONS]
 
 Options:
-      --path <PATH>        Specify the path of the project to be deployed. If not specified, the current directory is targeted
+      --path <PATH>        Specify the path of the project to deploy. If not specified, the current directory is targeted
   -v, --verbose...         Displays detailed information about operations. -vv will generate a very large number of messages and can affect performance
       --network <NETWORK>  Specify the network to execute on [default: local] [possible values: local, ic]
   -q, --quiet...           Suppresses informational messages. -qq limits to errors only; -qqqq disables them all

--- a/docs/index.md
+++ b/docs/index.md
@@ -373,14 +373,14 @@ example)
 
 ```yaml
 version: v1
-label: example_pj
+label: sample
 components:
-- component_path: components/example_algorithm_indexer.yaml
-- component_path: components/example_algorithm_lens.yaml
-- component_path: components/example_event_indexer.yaml
-- component_path: components/example_pj_relayer.yaml
-- component_path: components/example_pj_snapshot_chain.yaml
-- component_path: components/example_pj_snapshot_icp.yaml
+- component_path: components/sample_algorithm_indexer.yaml
+- component_path: components/sample_algorithm_lens.yaml
+- component_path: components/sample_event_indexer.yaml
+- component_path: components/sample_relayer.yaml
+- component_path: components/sample_snapshot_indexer_chain.yaml
+- component_path: components/sample_snapshot_indexer_icp.yaml
 ```
 
 ### Component Manifest
@@ -402,7 +402,7 @@ example)
 ```yaml
 version: v1
 metadata:
-  label: example_pj_snapshot_chain
+  label: sample_snapshot_indexer_chain
   type: snapshot_indexer
   description: ''
   tags: ...
@@ -452,7 +452,7 @@ example)
 ```yaml
 version: v1
 metadata:
-  label: example_pj_snapshot_chain
+  label: sample_snapshot_indexer_chain
   type: snapshot_indexer
   description: ''
   tags: ...
@@ -499,14 +499,14 @@ example)
 ```yaml
 version: v1
 metadata:
-  label: example_pj_snapshot_icp
+  label: sample_snapshot_indexer_icp
   type: snapshot_indexer
   description: ''
   tags: ...
 datasource:
   type: canister
   location:
-    id: sample_pj_snapshot_chain
+    id: sample_snapshot_indexer_chain
     args:
       id_type: canister_name
   method:
@@ -535,14 +535,14 @@ example)
 ```yaml
 version: v1
 metadata:
-  label: example_pj_relayer
+  label: sample_relayer
   type: relayer
   description: ''
   tags: ...
 datasource:
   type: canister
   location:
-    id: sample_pj_snapshot_chain
+    id: sample_snapshot_indexer_chain
     args:
       id_type: canister_name
   method:
@@ -599,7 +599,7 @@ Users can define arbitrary logic using Lens. All data sources on Chainsight can 
 ```yml
 version: v1
 metadata:
-  label: sample_pj_algorithm_lens
+  label: sample_algorithm_lens
   type: algorithm_lens
   description: ''
   tags:

--- a/resources/schema/snapshot_indexer.json
+++ b/resources/schema/snapshot_indexer.json
@@ -92,7 +92,7 @@
               "examples": [
                 "9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
                 "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
-                "pj_snapshot_chain",
+                "pj_snapshot_indexer_chain",
                 "rrkah-fqaaa-aaaaa-aaaaq-cai"
               ]
             },

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -41,14 +41,15 @@ use crate::{
 };
 
 #[derive(Debug, Parser)]
-#[command(name = "create")]
+#[command(name = "add")]
+#[clap(alias = "create")]
 /// Generates component manifest of specified type and adds to your project.
-pub struct CreateOpts {
-    /// Specifies the name of the component to create.
+pub struct AddOpts {
+    /// Specifies the name of the component to add.
     #[arg(required = true)]
     component_name: String,
 
-    /// Specifies type of the component to create.
+    /// Specifies type of the component to add.
     #[arg(long)]
     type_: ComponentType,
 
@@ -58,7 +59,7 @@ pub struct CreateOpts {
     path: Option<String>,
 }
 
-pub fn exec(env: &EnvironmentImpl, opts: CreateOpts) -> anyhow::Result<()> {
+pub fn exec(env: &EnvironmentImpl, opts: AddOpts) -> anyhow::Result<()> {
     let log = env.get_logger();
     let component_name = opts.component_name;
     let component_type = opts.type_;
@@ -137,7 +138,7 @@ pub fn exec(env: &EnvironmentImpl, opts: CreateOpts) -> anyhow::Result<()> {
 
     info!(
         log,
-        r#"{:?} component '{}' created successfully"#, component_type, component_name
+        r#"{:?} component '{}' added successfully"#, component_type, component_name
     );
 
     Ok(())

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -107,7 +107,7 @@ pub fn exec(env: &EnvironmentImpl, opts: BuildOpts) -> anyhow::Result<()> {
     if opts.only_build {
         info!(log, r#"Skip codegen"#);
     } else {
-        generate::exec(env, generate::GenerateOpts::new(opts.path.clone()))?;
+        generate::exec(env, generate::GenerateOpts::new(opts.path))?;
         info!(log, r#"Start building..."#);
     }
 
@@ -237,7 +237,7 @@ fn add_meta(
     let output = Command::new("ic-wasm")
         .current_dir(project_path_str)
         .args([
-            &wasm_path, "-o", &wasm_path, "metadata", key, "-d", value, "-v", "public",
+            wasm_path, "-o", wasm_path, "metadata", key, "-d", value, "-v", "public",
         ])
         .output()
         .unwrap_or_else(|_| panic!("failed to execute process: ic-wasm metadata {}", key));
@@ -268,7 +268,7 @@ fn add_metadata_to_wasm(
     let label = &component_datum.metadata().label.clone();
     let wasm_path = &format!("{}/{}.wasm", ARTIFACTS_DIR, label);
     let put_meta = |key: &str, value: &str| -> anyhow::Result<()> {
-        add_meta(label, key, value, wasm_path, &project_path_str, log)
+        add_meta(label, key, value, wasm_path, project_path_str, log)
     };
 
     put_meta("chainsight:label", label)?;

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -159,6 +159,33 @@ fn exec_codegen(
         fs::create_dir(artifacts_path)?;
     }
 
+    // generate workspace
+    let projects = component_data
+        .iter()
+        .map(|data| data.metadata().label.to_string())
+        .collect::<Vec<String>>();
+    if !Path::new(&format!("{}/Cargo.toml", &artifacts_path_str)).is_file() {
+        fs::write(
+            format!("{}/Cargo.toml", &artifacts_path_str),
+            root_cargo_toml(projects.clone()),
+        )?;
+    } else {
+        info!(log, r#"Skip creating: 'Cargo.toml' already exists"#,)
+    }
+    fs::write(
+        format!("{}/dfx.json", &artifacts_path_str),
+        dfx_json(projects),
+    )?;
+
+    if !Path::new(&format!("{}/Makefile.toml", &artifacts_path_str)).is_file() {
+        fs::write(
+            format!("{}/Makefile.toml", &artifacts_path_str),
+            makefile_toml(),
+        )?;
+    } else {
+        info!(log, r#"Skip creating: 'Makefile.toml' already exists"#,)
+    }
+
     // generate /artifacts/__interfaces
     let interfaces_path_str = format!("{}/__interfaces", &artifacts_path_str);
     fs::create_dir(&interfaces_path_str)?;
@@ -290,26 +317,6 @@ fn exec_codegen(
                 }
                 fs::write(path, content).unwrap();
             });
-    }
-    if !Path::new(&format!("{}/Cargo.toml", &artifacts_path_str)).is_file() {
-        fs::write(
-            format!("{}/Cargo.toml", &artifacts_path_str),
-            root_cargo_toml(project_labels.clone()),
-        )?;
-    } else {
-        info!(log, r#"Skip creating: 'Cargo.toml' already exists"#,)
-    }
-    fs::write(
-        format!("{}/dfx.json", &artifacts_path_str),
-        dfx_json(project_labels),
-    )?;
-    if !Path::new(&format!("{}/Makefile.toml", &artifacts_path_str)).is_file() {
-        fs::write(
-            format!("{}/Makefile.toml", &artifacts_path_str),
-            makefile_toml(),
-        )?;
-    } else {
-        info!(log, r#"Skip creating: 'Makefile.toml' already exists"#,)
     }
 
     anyhow::Ok(())

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -29,7 +29,7 @@ use crate::{
 #[command(name = "build")]
 /// Builds your project to generate canisters' modules for Chainsight.
 pub struct BuildOpts {
-    /// Specify the path of the project to be built.
+    /// Specify the path of the project to build.
     /// If not specified, the current directory is targeted.
     #[arg(long)]
     path: Option<String>,

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,13 +1,12 @@
 use std::fmt::Debug;
-use std::fs::File;
+use std::fs;
 use std::process::Command;
-use std::{fs, path::Path};
 
 use anyhow::{bail, Ok};
 use clap::Parser;
 use slog::{debug, info, Logger};
 
-use crate::lib::codegen::bindings::generate_rs_bindings;
+use crate::commands::generate;
 use crate::lib::codegen::components::algorithm_indexer::AlgorithmIndexerComponentManifest;
 use crate::lib::codegen::components::algorithm_lens::AlgorithmLensComponentManifest;
 use crate::lib::codegen::components::common::{ComponentManifest, ComponentTypeInManifest};
@@ -15,11 +14,7 @@ use crate::lib::codegen::components::event_indexer::EventIndexerComponentManifes
 use crate::lib::codegen::components::relayer::RelayerComponentManifest;
 use crate::lib::codegen::components::snapshot_indexer::SnapshotIndexerComponentManifest;
 use crate::lib::codegen::components::snapshot_indexer_https::SnapshotIndexerHTTPSComponentManifest;
-use crate::lib::codegen::oracle::get_oracle_attributes;
-use crate::lib::codegen::templates::{
-    bindings_cargo_toml, canister_project_cargo_toml, dfx_json, logic_cargo_toml,
-    root_cargo_toml,
-};
+use crate::lib::codegen::templates::dfx_json;
 use crate::lib::utils::{find_duplicates, paths, ARTIFACTS_DIR};
 use crate::{
     lib::{
@@ -30,10 +25,6 @@ use crate::{
     types::ComponentType,
 };
 
-fn dummy_candid_blob() -> String {
-    include_str!("../../resources/sample.did").to_string()
-}
-
 #[derive(Debug, Parser)]
 #[command(name = "build")]
 /// Builds your project to generate canisters' modules for Chainsight.
@@ -43,19 +34,15 @@ pub struct BuildOpts {
     #[arg(long)]
     path: Option<String>,
 
-    /// Only perform code generation.
-    #[arg(long, conflicts_with = "only_build")]
-    only_codegen: bool,
-
     /// Only perform build.
     /// Perform this steps with code already generated.
-    #[arg(long, conflicts_with = "only_codegen")]
+    #[arg(long)]
     only_build: bool,
 }
 
 pub fn exec(env: &EnvironmentImpl, opts: BuildOpts) -> anyhow::Result<()> {
     let log = env.get_logger();
-    let project_path = opts.path;
+    let project_path = opts.path.clone();
 
     if let Err(msg) = is_chainsight_project(project_path.clone()) {
         bail!(format!(r#"{}"#, msg));
@@ -73,7 +60,6 @@ pub fn exec(env: &EnvironmentImpl, opts: BuildOpts) -> anyhow::Result<()> {
         log,
         r#"Start building project '{}'"#, project_manifest.label
     );
-
     // check duplicated component paths
     {
         let component_paths = project_manifest
@@ -121,235 +107,19 @@ pub fn exec(env: &EnvironmentImpl, opts: BuildOpts) -> anyhow::Result<()> {
     if opts.only_build {
         info!(log, r#"Skip codegen"#);
     } else {
-        // generate codes
-        info!(log, r#"Start processing for codegen..."#);
-        exec_codegen(log, &project_path_str, &component_data)?;
-
-        info!(
-            log,
-            r#"Project '{}' codes/resources generated successfully"#, project_manifest.label
-        );
+        generate::exec(env, generate::GenerateOpts::new(opts.path.clone()))?;
+        info!(log, r#"Start building..."#);
     }
 
-    if opts.only_codegen {
-        info!(log, r#"Skip build"#);
-    } else {
-        // build codes generated
-        info!(log, r#"Start processing for build..."#);
-        execute_codebuild(log, &project_path_str, &component_data)?;
+    // build codes generated
+    execute_codebuild(log, &project_path_str, &component_data)?;
 
-        info!(
-            log,
-            r#"Project '{}' built successfully"#, project_manifest.label
-        );
-    }
+    info!(
+        log,
+        r#"Project '{}' built successfully"#, project_manifest.label
+    );
 
     Ok(())
-}
-
-fn exec_codegen(
-    log: &Logger,
-    project_path_str: &str,
-    component_data: &Vec<Box<dyn ComponentManifest>>,
-) -> anyhow::Result<()> {
-    // generate workspace
-    let src_path_str = &paths::src_path_str(project_path_str);
-    fs::create_dir_all(&format!("{}", src_path_str)).expect("failed to create dir: src");
-    if !Path::new(&format!("{}/Cargo.toml", src_path_str)).is_file() {
-        fs::write(format!("{}/Cargo.toml", src_path_str), root_cargo_toml())?;
-    } else {
-        info!(
-            log,
-            r#"Skip creating workspace: '{}/Cargo.toml' already exists"#, src_path_str
-        )
-    }
-
-    // remove generated files
-    let _ = fs::remove_dir_all(format!("{}/__interfaces", src_path_str));
-    let _ = fs::remove_dir_all(format!("{}/bindings", src_path_str));
-    let _ = fs::remove_dir_all(format!("{}/canisters", src_path_str));
-
-    // generate /artifacts/__interfaces
-    let interfaces_path_str = format!("{}/__interfaces", src_path_str);
-    fs::create_dir(&interfaces_path_str)?;
-    let dummy_candid_file_path = format!("{}/interfaces/{}", project_path_str, "sample.did");
-    if !Path::new(&dummy_candid_file_path).is_file() {
-        fs::write(&dummy_candid_file_path, dummy_candid_blob())?;
-    }
-
-    // generate canister projects
-    for data in component_data {
-        let label = data.metadata().label.to_string();
-
-        if let Err(msg) = data.validate_manifest() {
-            bail!(format!(r#"[{}] Invalid manifest: {}"#, label, msg));
-        }
-        info!(log, r#"[{}] Start processing..."#, label);
-
-        // logic template
-        let logic_path_str = &paths::logics_path_str(src_path_str, &label);
-        if Path::new(logic_path_str).is_dir() {
-            info!(
-                log,
-                r#"[{}] Skip creating logic project: '{}' already exists"#, label, logic_path_str,
-            );
-        } else {
-            create_cargo_project(
-                logic_path_str,
-                Option::Some(&logic_cargo_toml(&label, data.dependencies())),
-                Option::Some(
-                    &data
-                        .generate_user_impl_template()
-                        .unwrap_or_default()
-                        .to_string(),
-                ),
-            )
-            .map_err(|err| {
-                anyhow::anyhow!(r#"[{}] Failed to create logic project by: {}"#, label, err)
-            })?;
-        }
-
-        // Processes about interface
-        // - copy and move any necessary interfaces to canister
-        // - get ethabi::Contract for codegen
-        let mut interface_contract: Option<ethabi::Contract> = None;
-        if let Some(interface_file) = data.required_interface() {
-            let dst_interface_path_str = format!("{}/{}", &interfaces_path_str, &interface_file);
-            let dst_interface_path = Path::new(&dst_interface_path_str);
-
-            let user_if_file_path_str =
-                format!("{}/interfaces/{}", project_path_str, &interface_file);
-            let user_if_file_path = Path::new(&user_if_file_path_str);
-            if user_if_file_path.exists() {
-                fs::copy(user_if_file_path, dst_interface_path)?;
-                info!(
-                    log,
-                    r#"[{}] Interface file '{}' copied from user's interface"#,
-                    label,
-                    &interface_file
-                );
-                let abi_file = File::open(user_if_file_path)?;
-                interface_contract = Some(ethabi::Contract::load(abi_file)?);
-            } else if let Some(contents) = builtin_interface(&interface_file) {
-                fs::write(dst_interface_path, contents)?;
-                info!(
-                    log,
-                    r#"[{}] Interface file '{}' copied from builtin interface"#,
-                    label,
-                    &interface_file
-                );
-                let contract: ethabi::Contract = serde_json::from_str(contents)?;
-                interface_contract = Some(contract);
-            } else {
-                bail!(format!(
-                    r#"[{}] Interface file "{}" not found"#,
-                    label, &interface_file
-                ));
-            }
-        }
-
-        // copy and move oracle interface
-        if let Some(value) = data.destination_type() {
-            let (_, json_name, json_contents) = get_oracle_attributes(&value);
-            fs::write(
-                format!("{}/{}", &interfaces_path_str, &json_name),
-                json_contents,
-            )?;
-            info!(
-                log,
-                r#"[{}] Interface file '{}' copied from builtin interface"#, label, &json_name
-            );
-        }
-
-        // canister
-        let canister_pj_path_str = &paths::canisters_path_str(src_path_str, &label);
-        let canister_src = &data.generate_codes(interface_contract).map_err(|err| {
-            anyhow::anyhow!(
-                r#"[{}] Failed to generate canister code by: {}"#,
-                label,
-                err
-            )
-        })?;
-        create_cargo_project(
-            canister_pj_path_str,
-            Option::Some(&canister_project_cargo_toml(&label)),
-            Option::Some(&canister_src.to_string()),
-        )
-        .map_err(|err| {
-            anyhow::anyhow!(
-                r#"[{}] Failed to create canister project by: {}"#,
-                label,
-                err
-            )
-        })?;
-
-        // generate dummy bindings to be able to run cargo test
-        let bindings_path_str = &paths::bindings_path_str(src_path_str, &label);
-        create_cargo_project(
-            bindings_path_str,
-            Option::Some(&bindings_cargo_toml(&label)),
-            Option::None,
-        )
-        .map_err(|err| {
-            anyhow::anyhow!(
-                r#"[{}] Failed to create bindings project by: {}"#,
-                label,
-                err
-            )
-        })?;
-    }
-
-    // generate canister bindings
-    let action = "Generate interfaces (.did files)";
-    info!(log, "{}...", action);
-    for data in component_data {
-        let label = data.metadata().label.to_string();
-        let canisters_path_str = paths::canisters_path_str(src_path_str, &label);
-
-        let output = Command::new("cargo")
-            .current_dir(canisters_path_str)
-            .args(["test"])
-            .output()
-            .expect("failed to execute: cargo test");
-
-        if output.status.success() {
-            debug!(
-                log,
-                "{}",
-                std::str::from_utf8(&output.stdout).unwrap_or("failed to parse stdout")
-            );
-            info!(log, r#"[{}] Succeeded: {}"#, label, action);
-        } else {
-            bail!(format!(
-                r#"[{}] Failed: {} by: {}"#,
-                label,
-                action,
-                std::str::from_utf8(&output.stderr).unwrap_or("failed to parse stdout")
-            ));
-        }
-
-        // TODO handle errors
-        let bindings = generate_rs_bindings(src_path_str, data)?;
-        fs::write(
-            Path::new(&format!(
-                "{}/src/lib.rs",
-                paths::bindings_path_str(src_path_str, &label)
-            )),
-            bindings,
-        )
-        .expect("failed to execute: write bindings");
-    }
-
-    anyhow::Ok(())
-}
-
-fn builtin_interface(name: &str) -> Option<&'static str> {
-    let interface = match name {
-        "ERC20.json" => include_str!("../../resources/ERC20.json"),
-        _ => return None,
-    };
-
-    Some(interface)
 }
 
 fn execute_codebuild(
@@ -520,21 +290,4 @@ fn add_metadata_to_wasm(
         put_meta(key, value)?;
     }
     anyhow::Ok(())
-}
-
-pub fn create_cargo_project(
-    path_str: &str,
-    manifest: Option<&str>,
-    src: Option<&str>,
-) -> anyhow::Result<()> {
-    fs::create_dir_all(Path::new(&format!("{}/src", path_str)))?;
-    fs::write(
-        Path::new(&format!("{}/Cargo.toml", path_str)),
-        manifest.unwrap_or_default(),
-    )?;
-    fs::write(
-        Path::new(&format!("{}/src/lib.rs", path_str)),
-        src.unwrap_or_default(),
-    )?;
-    Ok(())
 }

--- a/src/commands/deploy.rs
+++ b/src/commands/deploy.rs
@@ -18,7 +18,7 @@ use crate::{
 /// Deploy the components of your project.
 /// If you want to operate on a local network, you need to build a local dfx network in advance.
 pub struct DeployOpts {
-    /// Specify the path of the project to be deployed.
+    /// Specify the path of the project to deploy.
     /// If not specified, the current directory is targeted.
     #[arg(long)]
     path: Option<String>,

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -235,6 +235,7 @@ mod tests {
             &&test_env(),
             new::NewOpts {
                 project_name: project_name.to_string(),
+                no_samples: false,
             },
         );
     }

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -1,0 +1,347 @@
+use std::fmt::Debug;
+use std::fs::File;
+use std::process::Command;
+use std::{fs, path::Path};
+
+use anyhow::{bail, Ok};
+use clap::Parser;
+use slog::{debug, info, Logger};
+
+use crate::lib::codegen::bindings::generate_rs_bindings;
+use crate::lib::codegen::components::algorithm_indexer::AlgorithmIndexerComponentManifest;
+use crate::lib::codegen::components::algorithm_lens::AlgorithmLensComponentManifest;
+use crate::lib::codegen::components::common::{ComponentManifest, ComponentTypeInManifest};
+use crate::lib::codegen::components::event_indexer::EventIndexerComponentManifest;
+use crate::lib::codegen::components::relayer::RelayerComponentManifest;
+use crate::lib::codegen::components::snapshot_indexer::SnapshotIndexerComponentManifest;
+use crate::lib::codegen::components::snapshot_indexer_https::SnapshotIndexerHTTPSComponentManifest;
+use crate::lib::codegen::oracle::get_oracle_attributes;
+use crate::lib::codegen::templates::{
+    bindings_cargo_toml, canister_project_cargo_toml, logic_cargo_toml, root_cargo_toml,
+};
+use crate::lib::utils::{find_duplicates, paths};
+use crate::{
+    lib::{
+        codegen::project::ProjectManifestData,
+        environment::EnvironmentImpl,
+        utils::{is_chainsight_project, PROJECT_MANIFEST_FILENAME},
+    },
+    types::ComponentType,
+};
+
+fn dummy_candid_blob() -> String {
+    include_str!("../../resources/sample.did").to_string()
+}
+
+#[derive(Debug, Parser)]
+#[command(name = "generate")]
+#[clap(visible_alias = "gen")]
+/// Builds your project to generate canisters' modules for Chainsight.
+pub struct GenerateOpts {
+    /// Specify the path of the project to be built.
+    /// If not specified, the current directory is targeted.
+    #[arg(long)]
+    path: Option<String>,
+}
+
+impl GenerateOpts {
+    pub fn new(path: Option<String>) -> Self {
+        Self { path }
+    }
+}
+
+pub fn exec(env: &EnvironmentImpl, opts: GenerateOpts) -> anyhow::Result<()> {
+    let log = env.get_logger();
+    let project_path = opts.path;
+
+    if let Err(msg) = is_chainsight_project(project_path.clone()) {
+        bail!(format!(r#"{}"#, msg));
+    }
+
+    let project_path_str = project_path.unwrap_or(".".to_string());
+
+    // load component definitions from manifests
+    let project_manifest = ProjectManifestData::load(&format!(
+        "{}/{}",
+        &project_path_str, PROJECT_MANIFEST_FILENAME
+    ))?;
+
+    info!(
+        log,
+        r#"Start code generation for project '{}'"#, project_manifest.label
+    );
+
+    // check duplicated component paths
+    {
+        let component_paths = project_manifest
+            .components
+            .iter()
+            .map(|c| c.component_path.to_string())
+            .collect::<Vec<String>>();
+        let duplicated_paths = find_duplicates(&component_paths);
+        if !duplicated_paths.is_empty() {
+            bail!(format!(
+                r#"Duplicated component paths found: {:?}"#,
+                duplicated_paths
+            ));
+        }
+    }
+
+    let mut component_data = vec![];
+    for component in project_manifest.components.clone() {
+        // TODO: need validations
+        let relative_component_path = component.component_path;
+        let component_path = format!("{}/{}", &project_path_str, relative_component_path);
+        let component_type = ComponentTypeInManifest::determine_type(&component_path)?;
+
+        let data: Box<dyn ComponentManifest> = match component_type {
+            ComponentType::EventIndexer => {
+                Box::new(EventIndexerComponentManifest::load(&component_path)?)
+            }
+            ComponentType::AlgorithmIndexer => {
+                Box::new(AlgorithmIndexerComponentManifest::load(&component_path)?)
+            }
+            ComponentType::SnapshotIndexer => {
+                Box::new(SnapshotIndexerComponentManifest::load(&component_path)?)
+            }
+            ComponentType::Relayer => Box::new(RelayerComponentManifest::load(&component_path)?),
+            ComponentType::AlgorithmLens => {
+                Box::new(AlgorithmLensComponentManifest::load(&component_path)?)
+            }
+            ComponentType::SnapshotIndexerHTTPS => Box::new(
+                SnapshotIndexerHTTPSComponentManifest::load(&component_path)?,
+            ),
+        };
+        component_data.push(data);
+    }
+
+    exec_codegen(log, &project_path_str, &component_data)?;
+
+    info!(
+        log,
+        r#"Project '{}' codes/resources generated successfully"#, project_manifest.label
+    );
+    Ok(())
+}
+
+fn exec_codegen(
+    log: &Logger,
+    project_path_str: &str,
+    component_data: &Vec<Box<dyn ComponentManifest>>,
+) -> anyhow::Result<()> {
+    // generate workspace
+    let src_path_str = &paths::src_path_str(project_path_str);
+    fs::create_dir_all(&format!("{}", src_path_str)).expect("failed to create dir: src");
+    if !Path::new(&format!("{}/Cargo.toml", src_path_str)).is_file() {
+        fs::write(format!("{}/Cargo.toml", src_path_str), root_cargo_toml())?;
+    } else {
+        info!(
+            log,
+            r#"Skip creating workspace: '{}/Cargo.toml' already exists"#, src_path_str
+        )
+    }
+
+    // remove generated files
+    let _ = fs::remove_dir_all(format!("{}/__interfaces", src_path_str));
+    let _ = fs::remove_dir_all(format!("{}/bindings", src_path_str));
+    let _ = fs::remove_dir_all(format!("{}/canisters", src_path_str));
+
+    // generate /artifacts/__interfaces
+    let interfaces_path_str = format!("{}/__interfaces", src_path_str);
+    fs::create_dir(&interfaces_path_str)?;
+    let dummy_candid_file_path = format!("{}/interfaces/{}", project_path_str, "sample.did");
+    if !Path::new(&dummy_candid_file_path).is_file() {
+        fs::write(&dummy_candid_file_path, dummy_candid_blob())?;
+    }
+
+    // generate canister projects
+    for data in component_data {
+        let label = data.metadata().label.to_string();
+
+        if let Err(msg) = data.validate_manifest() {
+            bail!(format!(r#"[{}] Invalid manifest: {}"#, label, msg));
+        }
+        info!(log, r#"[{}] Start processing..."#, label);
+
+        // logic template
+        let logic_path_str = &paths::logics_path_str(src_path_str, &label);
+        if Path::new(logic_path_str).is_dir() {
+            info!(
+                log,
+                r#"[{}] Skip creating logic project: '{}' already exists"#, label, logic_path_str,
+            );
+        } else {
+            create_cargo_project(
+                logic_path_str,
+                Option::Some(&logic_cargo_toml(&label, data.dependencies())),
+                Option::Some(
+                    &data
+                        .generate_user_impl_template()
+                        .unwrap_or_default()
+                        .to_string(),
+                ),
+            )
+            .map_err(|err| {
+                anyhow::anyhow!(r#"[{}] Failed to create logic project by: {}"#, label, err)
+            })?;
+        }
+
+        // Processes about interface
+        // - copy and move any necessary interfaces to canister
+        // - get ethabi::Contract for codegen
+        let mut interface_contract: Option<ethabi::Contract> = None;
+        if let Some(interface_file) = data.required_interface() {
+            let dst_interface_path_str = format!("{}/{}", &interfaces_path_str, &interface_file);
+            let dst_interface_path = Path::new(&dst_interface_path_str);
+
+            let user_if_file_path_str =
+                format!("{}/interfaces/{}", project_path_str, &interface_file);
+            let user_if_file_path = Path::new(&user_if_file_path_str);
+            if user_if_file_path.exists() {
+                fs::copy(user_if_file_path, dst_interface_path)?;
+                info!(
+                    log,
+                    r#"[{}] Interface file '{}' copied from user's interface"#,
+                    label,
+                    &interface_file
+                );
+                let abi_file = File::open(user_if_file_path)?;
+                interface_contract = Some(ethabi::Contract::load(abi_file)?);
+            } else if let Some(contents) = builtin_interface(&interface_file) {
+                fs::write(dst_interface_path, contents)?;
+                info!(
+                    log,
+                    r#"[{}] Interface file '{}' copied from builtin interface"#,
+                    label,
+                    &interface_file
+                );
+                let contract: ethabi::Contract = serde_json::from_str(contents)?;
+                interface_contract = Some(contract);
+            } else {
+                bail!(format!(
+                    r#"[{}] Interface file "{}" not found"#,
+                    label, &interface_file
+                ));
+            }
+        }
+
+        // copy and move oracle interface
+        if let Some(value) = data.destination_type() {
+            let (_, json_name, json_contents) = get_oracle_attributes(&value);
+            fs::write(
+                format!("{}/{}", &interfaces_path_str, &json_name),
+                json_contents,
+            )?;
+            info!(
+                log,
+                r#"[{}] Interface file '{}' copied from builtin interface"#, label, &json_name
+            );
+        }
+
+        // canister
+        let canister_pj_path_str = &paths::canisters_path_str(src_path_str, &label);
+        let canister_src = &data.generate_codes(interface_contract).map_err(|err| {
+            anyhow::anyhow!(
+                r#"[{}] Failed to generate canister code by: {}"#,
+                label,
+                err
+            )
+        })?;
+        create_cargo_project(
+            canister_pj_path_str,
+            Option::Some(&canister_project_cargo_toml(&label)),
+            Option::Some(&canister_src.to_string()),
+        )
+        .map_err(|err| {
+            anyhow::anyhow!(
+                r#"[{}] Failed to create canister project by: {}"#,
+                label,
+                err
+            )
+        })?;
+
+        // generate dummy bindings to be able to run cargo test
+        let bindings_path_str = &paths::bindings_path_str(src_path_str, &label);
+        create_cargo_project(
+            bindings_path_str,
+            Option::Some(&bindings_cargo_toml(&label)),
+            Option::None,
+        )
+        .map_err(|err| {
+            anyhow::anyhow!(
+                r#"[{}] Failed to create bindings project by: {}"#,
+                label,
+                err
+            )
+        })?;
+    }
+
+    // generate canister bindings
+    let action = "Generate interfaces (.did files)";
+    info!(log, "{}...", action);
+    for data in component_data {
+        let label = data.metadata().label.to_string();
+        let canisters_path_str = paths::canisters_path_str(src_path_str, &label);
+
+        let output = Command::new("cargo")
+            .current_dir(canisters_path_str)
+            .args(["test"])
+            .output()
+            .expect("failed to execute: cargo test");
+
+        if output.status.success() {
+            debug!(
+                log,
+                "{}",
+                std::str::from_utf8(&output.stdout).unwrap_or("failed to parse stdout")
+            );
+            info!(log, r#"[{}] Succeeded: {}"#, label, action);
+        } else {
+            bail!(format!(
+                r#"[{}] Failed: {} by: {}"#,
+                label,
+                action,
+                std::str::from_utf8(&output.stderr).unwrap_or("failed to parse stdout")
+            ));
+        }
+
+        // TODO handle errors
+        let bindings = generate_rs_bindings(src_path_str, data)?;
+        fs::write(
+            Path::new(&format!(
+                "{}/src/lib.rs",
+                paths::bindings_path_str(src_path_str, &label)
+            )),
+            bindings,
+        )
+        .expect("failed to execute: write bindings");
+    }
+
+    anyhow::Ok(())
+}
+
+fn builtin_interface(name: &str) -> Option<&'static str> {
+    let interface = match name {
+        "ERC20.json" => include_str!("../../resources/ERC20.json"),
+        _ => return None,
+    };
+
+    Some(interface)
+}
+
+pub fn create_cargo_project(
+    path_str: &str,
+    manifest: Option<&str>,
+    src: Option<&str>,
+) -> anyhow::Result<()> {
+    fs::create_dir_all(Path::new(&format!("{}/src", path_str)))?;
+    fs::write(
+        Path::new(&format!("{}/Cargo.toml", path_str)),
+        manifest.unwrap_or_default(),
+    )?;
+    fs::write(
+        Path::new(&format!("{}/src/lib.rs", path_str)),
+        src.unwrap_or_default(),
+    )?;
+    Ok(())
+}

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -36,9 +36,9 @@ fn dummy_candid_blob() -> String {
 #[derive(Debug, Parser)]
 #[command(name = "generate")]
 #[clap(visible_alias = "gen")]
-/// Builds your project to generate canisters' modules for Chainsight.
+/// Generate codes according to project/component manifests.
 pub struct GenerateOpts {
-    /// Specify the path of the project to be built.
+    /// Specify the path of the project.
     /// If not specified, the current directory is targeted.
     #[arg(long)]
     path: Option<String>,

--- a/src/commands/generate.rs
+++ b/src/commands/generate.rs
@@ -131,7 +131,7 @@ fn exec_codegen(
 ) -> anyhow::Result<()> {
     // generate workspace
     let src_path_str = &paths::src_path_str(project_path_str);
-    fs::create_dir_all(&format!("{}", src_path_str)).expect("failed to create dir: src");
+    fs::create_dir_all(src_path_str).expect("failed to create dir: src");
     if !Path::new(&format!("{}/Cargo.toml", src_path_str)).is_file() {
         fs::write(format!("{}/Cargo.toml", src_path_str), root_cargo_toml())?;
     } else {
@@ -306,7 +306,7 @@ fn exec_codegen(
         }
 
         // TODO handle errors
-        let bindings = generate_rs_bindings(src_path_str, data)?;
+        let bindings = generate_rs_bindings(src_path_str, data.as_ref())?;
         fs::write(
             Path::new(&format!(
                 "{}/src/lib.rs",

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -2,12 +2,13 @@ use clap::Subcommand;
 
 use crate::lib::environment::EnvironmentImpl;
 
+mod add;
 mod auth;
 mod build;
 mod config;
-mod create;
 mod deploy;
 mod exec;
+mod generate;
 mod new;
 mod remove;
 mod test;
@@ -18,7 +19,8 @@ pub enum Command {
     // Config(config::ConfigOpts),
     // Auth(auth::AuthOpts),
     New(new::NewOpts),
-    Create(create::CreateOpts),
+    Add(add::AddOpts),
+    Generate(generate::GenerateOpts),
     Build(build::BuildOpts),
     // Test(test::TestOpts),
     Deploy(deploy::DeployOpts),
@@ -38,7 +40,8 @@ pub fn exec(env: &EnvironmentImpl, cmd: Command) -> anyhow::Result<()> {
         //     Ok(())
         // }
         Command::New(opts) => new::exec(env, opts),
-        Command::Create(opts) => create::exec(env, opts),
+        Command::Add(opts) => add::exec(env, opts),
+        Command::Generate(opts) => generate::exec(env, opts),
         Command::Build(opts) => build::exec(env, opts),
         // Command::Test(_) => {
         //     println!("Not implemented yet...");

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -103,9 +103,12 @@ fn create_sample_components(project_name: &str, component_prefix: &str) -> anyho
     let relative_event_indexer_path = format!("components/{}_event_indexer.yaml", component_prefix);
     let relative_algorithm_indexer_path =
         format!("components/{}_algorithm_indexer.yaml", component_prefix);
-    let relative_snapshot_chain_path =
-        format!("components/{}_snapshot_chain.yaml", component_prefix);
-    let relative_snapshot_icp_path = format!("components/{}_snapshot_icp.yaml", component_prefix);
+    let relative_snapshot_indexer_chain_path = format!(
+        "components/{}_snapshot_indexer_chain.yaml",
+        component_prefix
+    );
+    let relative_snapshot_indexer_icp_path =
+        format!("components/{}_snapshot_indexer_icp.yaml", component_prefix);
     let relative_relayer_path = format!("components/{}_relayer.yaml", component_prefix);
     let relative_algorithmlens_path =
         format!("components/{}_algorithm_lens.yaml", component_prefix);
@@ -121,8 +124,8 @@ fn create_sample_components(project_name: &str, component_prefix: &str) -> anyho
             &[
                 ProjectManifestComponentField::new(&relative_event_indexer_path, None),
                 ProjectManifestComponentField::new(&relative_algorithm_indexer_path, None),
-                ProjectManifestComponentField::new(&relative_snapshot_chain_path, None),
-                ProjectManifestComponentField::new(&relative_snapshot_icp_path, None),
+                ProjectManifestComponentField::new(&relative_snapshot_indexer_chain_path, None),
+                ProjectManifestComponentField::new(&relative_snapshot_indexer_icp_path, None),
                 ProjectManifestComponentField::new(&relative_relayer_path, None),
                 ProjectManifestComponentField::new(&relative_algorithmlens_path, None),
                 ProjectManifestComponentField::new(&relative_snapshot_indexer_https_path, None),
@@ -139,12 +142,12 @@ fn create_sample_components(project_name: &str, component_prefix: &str) -> anyho
         template_algorithm_indexer_manifest(component_prefix).to_str_as_yaml()?,
     )?;
     fs::write(
-        format!("{}/{}", project_name, relative_snapshot_chain_path),
-        template_snapshot_chain_manifest(component_prefix).to_str_as_yaml()?,
+        format!("{}/{}", project_name, relative_snapshot_indexer_chain_path),
+        template_snapshot_indexer_chain_manifest(component_prefix).to_str_as_yaml()?,
     )?;
     fs::write(
-        format!("{}/{}", project_name, relative_snapshot_icp_path),
-        template_snapshot_icp_manifest(component_prefix).to_str_as_yaml()?,
+        format!("{}/{}", project_name, relative_snapshot_indexer_icp_path),
+        template_snapshot_indexer_icp_manifest(component_prefix).to_str_as_yaml()?,
     )?;
     fs::write(
         format!("{}/{}", project_name, relative_relayer_path),
@@ -183,9 +186,9 @@ fn template_algorithm_indexer_manifest(prefix: &str) -> AlgorithmIndexerComponen
     )
 }
 
-fn template_snapshot_chain_manifest(prefix: &str) -> SnapshotIndexerComponentManifest {
+fn template_snapshot_indexer_chain_manifest(prefix: &str) -> SnapshotIndexerComponentManifest {
     SnapshotIndexerComponentManifest::new(
-        &format!("{}_snapshot_chain", prefix),
+        &format!("{}_snapshot_indexer_chain", prefix),
         "",
         PROJECT_MANIFEST_VERSION,
         Datasource::default_contract(),
@@ -194,9 +197,9 @@ fn template_snapshot_chain_manifest(prefix: &str) -> SnapshotIndexerComponentMan
     )
 }
 
-fn template_snapshot_icp_manifest(prefix: &str) -> SnapshotIndexerComponentManifest {
+fn template_snapshot_indexer_icp_manifest(prefix: &str) -> SnapshotIndexerComponentManifest {
     SnapshotIndexerComponentManifest::new(
-        &format!("{}_snapshot_icp", prefix),
+        &format!("{}_snapshot_indexer_icp", prefix),
         "",
         PROJECT_MANIFEST_VERSION,
         Datasource::default_canister(true),
@@ -261,8 +264,8 @@ mod tests {
                 vec![
                     "event_indexer",
                     "algorithm_indexer",
-                    "snapshot_chain",
-                    "snapshot_icp",
+                    "snapshot_indexer_chain",
+                    "snapshot_indexer_icp",
                     "relayer",
                     "algorithm_lens",
                     "snapshot_indexer_https",

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -23,9 +23,13 @@ use crate::lib::{
             },
         },
         project::{ProjectManifestComponentField, ProjectManifestData},
+        templates::gitignore,
     },
     environment::EnvironmentImpl,
-    utils::{CHAINSIGHT_FILENAME, PROJECT_MANIFEST_FILENAME, PROJECT_MANIFEST_VERSION},
+    utils::{
+        CHAINSIGHT_FILENAME, GITIGNORE_FILENAME, PROJECT_MANIFEST_FILENAME,
+        PROJECT_MANIFEST_VERSION,
+    },
 };
 
 #[derive(Debug, Parser)]
@@ -66,6 +70,10 @@ fn create_project(project_name: &str) -> anyhow::Result<()> {
     fs::create_dir_all(format!("{}/interfaces", project_name))?;
 
     // Create files
+    fs::write(
+        format!("{}/{}", project_name, GITIGNORE_FILENAME),
+        gitignore(),
+    )?;
     fs::write(format!("{}/{}", project_name, CHAINSIGHT_FILENAME), "")?;
     let relative_event_indexer_path = format!("components/{}_event_indexer.yaml", project_name);
     let relative_algorithm_indexer_path =

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -88,7 +88,7 @@ fn create_project(project_name: &str, no_samples: bool) -> anyhow::Result<()> {
     fs::write(format!("{}/{}", project_name, CHAINSIGHT_FILENAME), "")?;
 
     if !no_samples {
-        return create_sample_components(project_name);
+        return create_sample_components(project_name, "sample");
     }
 
     fs::write(
@@ -99,16 +99,20 @@ fn create_project(project_name: &str, no_samples: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn create_sample_components(project_name: &str) -> anyhow::Result<()> {
-    let relative_event_indexer_path = format!("components/{}_event_indexer.yaml", project_name);
+fn create_sample_components(project_name: &str, component_prefix: &str) -> anyhow::Result<()> {
+    let relative_event_indexer_path = format!("components/{}_event_indexer.yaml", component_prefix);
     let relative_algorithm_indexer_path =
-        format!("components/{}_algorithm_indexer.yaml", project_name);
-    let relative_snapshot_chain_path = format!("components/{}_snapshot_chain.yaml", project_name);
-    let relative_snapshot_icp_path = format!("components/{}_snapshot_icp.yaml", project_name);
-    let relative_relayer_path = format!("components/{}_relayer.yaml", project_name);
-    let relative_algorithmlens_path = format!("components/{}_algorithm_lens.yaml", project_name);
-    let relative_snapshot_indexer_https_path =
-        format!("components/{}_snapshot_indexer_https.yaml", project_name);
+        format!("components/{}_algorithm_indexer.yaml", component_prefix);
+    let relative_snapshot_chain_path =
+        format!("components/{}_snapshot_chain.yaml", component_prefix);
+    let relative_snapshot_icp_path = format!("components/{}_snapshot_icp.yaml", component_prefix);
+    let relative_relayer_path = format!("components/{}_relayer.yaml", component_prefix);
+    let relative_algorithmlens_path =
+        format!("components/{}_algorithm_lens.yaml", component_prefix);
+    let relative_snapshot_indexer_https_path = format!(
+        "components/{}_snapshot_indexer_https.yaml",
+        component_prefix
+    );
     fs::write(
         format!("{}/{}", project_name, PROJECT_MANIFEST_FILENAME),
         ProjectManifestData::new(
@@ -128,39 +132,39 @@ fn create_sample_components(project_name: &str) -> anyhow::Result<()> {
     )?;
     fs::write(
         format!("{}/{}", project_name, relative_event_indexer_path),
-        template_event_indexer_manifest(project_name).to_str_as_yaml()?,
+        template_event_indexer_manifest(component_prefix).to_str_as_yaml()?,
     )?;
     fs::write(
         format!("{}/{}", project_name, relative_algorithm_indexer_path),
-        template_algorithm_indexer_manifest(project_name).to_str_as_yaml()?,
+        template_algorithm_indexer_manifest(component_prefix).to_str_as_yaml()?,
     )?;
     fs::write(
         format!("{}/{}", project_name, relative_snapshot_chain_path),
-        template_snapshot_chain_manifest(project_name).to_str_as_yaml()?,
+        template_snapshot_chain_manifest(component_prefix).to_str_as_yaml()?,
     )?;
     fs::write(
         format!("{}/{}", project_name, relative_snapshot_icp_path),
-        template_snapshot_icp_manifest(project_name).to_str_as_yaml()?,
+        template_snapshot_icp_manifest(component_prefix).to_str_as_yaml()?,
     )?;
     fs::write(
         format!("{}/{}", project_name, relative_relayer_path),
-        template_relayer_manifest(project_name).to_str_as_yaml()?,
+        template_relayer_manifest(component_prefix).to_str_as_yaml()?,
     )?;
     fs::write(
         format!("{}/{}", project_name, relative_algorithmlens_path),
-        tempalte_algorithm_lens_manifest(project_name).to_str_as_yaml()?,
+        tempalte_algorithm_lens_manifest(component_prefix).to_str_as_yaml()?,
     )?;
     fs::write(
         format!("{}/{}", project_name, relative_snapshot_indexer_https_path),
-        template_snapshot_indexer_https_manifest(project_name).to_str_as_yaml()?,
+        template_snapshot_indexer_https_manifest(component_prefix).to_str_as_yaml()?,
     )?;
 
     Ok(())
 }
 
-fn template_event_indexer_manifest(project_name: &str) -> EventIndexerComponentManifest {
+fn template_event_indexer_manifest(prefix: &str) -> EventIndexerComponentManifest {
     EventIndexerComponentManifest::new(
-        &format!("{}_event_indexer", project_name),
+        &format!("{}_event_indexer", prefix),
         "",
         PROJECT_MANIFEST_VERSION,
         EventIndexerDatasource::default(),
@@ -168,9 +172,9 @@ fn template_event_indexer_manifest(project_name: &str) -> EventIndexerComponentM
     )
 }
 
-fn template_algorithm_indexer_manifest(project_name: &str) -> AlgorithmIndexerComponentManifest {
+fn template_algorithm_indexer_manifest(prefix: &str) -> AlgorithmIndexerComponentManifest {
     AlgorithmIndexerComponentManifest::new(
-        &format!("{}_algorithm_indexer", project_name),
+        &format!("{}_algorithm_indexer", prefix),
         "",
         PROJECT_MANIFEST_VERSION,
         AlgorithmIndexerDatasource::default(),
@@ -179,9 +183,9 @@ fn template_algorithm_indexer_manifest(project_name: &str) -> AlgorithmIndexerCo
     )
 }
 
-fn template_snapshot_chain_manifest(project_name: &str) -> SnapshotIndexerComponentManifest {
+fn template_snapshot_chain_manifest(prefix: &str) -> SnapshotIndexerComponentManifest {
     SnapshotIndexerComponentManifest::new(
-        &format!("{}_snapshot_chain", project_name),
+        &format!("{}_snapshot_chain", prefix),
         "",
         PROJECT_MANIFEST_VERSION,
         Datasource::default_contract(),
@@ -190,9 +194,9 @@ fn template_snapshot_chain_manifest(project_name: &str) -> SnapshotIndexerCompon
     )
 }
 
-fn template_snapshot_icp_manifest(project_name: &str) -> SnapshotIndexerComponentManifest {
+fn template_snapshot_icp_manifest(prefix: &str) -> SnapshotIndexerComponentManifest {
     SnapshotIndexerComponentManifest::new(
-        &format!("{}_snapshot_icp", project_name),
+        &format!("{}_snapshot_icp", prefix),
         "",
         PROJECT_MANIFEST_VERSION,
         Datasource::default_canister(true),
@@ -201,11 +205,9 @@ fn template_snapshot_icp_manifest(project_name: &str) -> SnapshotIndexerComponen
     )
 }
 
-fn template_snapshot_indexer_https_manifest(
-    project_name: &str,
-) -> SnapshotIndexerHTTPSComponentManifest {
+fn template_snapshot_indexer_https_manifest(prefix: &str) -> SnapshotIndexerHTTPSComponentManifest {
     SnapshotIndexerHTTPSComponentManifest::new(
-        &format!("{}_snapshot_indexer_https", project_name),
+        &format!("{}_snapshot_indexer_https", prefix),
         "",
         PROJECT_MANIFEST_VERSION,
         SnapshotIndexerHTTPSDataSource::default(),
@@ -214,9 +216,9 @@ fn template_snapshot_indexer_https_manifest(
     )
 }
 
-fn template_relayer_manifest(project_name: &str) -> RelayerComponentManifest {
+fn template_relayer_manifest(prefix: &str) -> RelayerComponentManifest {
     RelayerComponentManifest::new(
-        &format!("{}_relayer", project_name),
+        &format!("{}_relayer", prefix),
         "",
         PROJECT_MANIFEST_VERSION,
         Datasource::default_canister(false),
@@ -224,9 +226,9 @@ fn template_relayer_manifest(project_name: &str) -> RelayerComponentManifest {
         3600,
     )
 }
-fn tempalte_algorithm_lens_manifest(project_name: &str) -> AlgorithmLensComponentManifest {
+fn tempalte_algorithm_lens_manifest(prefix: &str) -> AlgorithmLensComponentManifest {
     AlgorithmLensComponentManifest::new(
-        &format!("{}_algorithm_lens", project_name),
+        &format!("{}_algorithm_lens", prefix),
         "",
         PROJECT_MANIFEST_VERSION,
         AlgorithmLensDataSource::default(),
@@ -245,6 +247,7 @@ mod tests {
     #[test]
     fn test_create_project() {
         let project_name = "new_test_create_project";
+        let component_prefix = "sample";
         run_with_teardown(
             || {
                 let created = create_project(project_name, false);
@@ -267,7 +270,7 @@ mod tests {
                 .for_each(|manifest| {
                     assert!(Path::new(&format!(
                         "{}/components/{}_{}.yaml",
-                        project_name, project_name, manifest
+                        project_name, component_prefix, manifest
                     ))
                     .exists());
                 });
@@ -282,11 +285,12 @@ mod tests {
         let project_name = "new_test_exec";
         run_with_teardown(
             || {
+                let env = &test_env();
                 let opts = NewOpts {
                     project_name: project_name.to_string(),
                     no_samples: false,
                 };
-                let res = exec(&test_env(), opts);
+                let res = exec(env, opts);
                 assert!(res.is_ok());
             },
             || teardown(project_name),

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -257,6 +257,7 @@ mod tests {
                 assert!(
                     Path::new(&format!("{}/{}", project_name, PROJECT_MANIFEST_FILENAME)).exists()
                 );
+                assert!(Path::new(&format!("{}/{}", project_name, GITIGNORE_FILENAME)).exists());
                 vec![
                     "event_indexer",
                     "algorithm_indexer",
@@ -274,6 +275,30 @@ mod tests {
                     ))
                     .exists());
                 });
+            },
+            || {
+                teardown(project_name);
+            },
+        )
+    }
+    #[test]
+    fn test_create_project_without_samples() {
+        let project_name = "new_test_create_project_without_samples";
+        run_with_teardown(
+            || {
+                let created = create_project(project_name, true);
+                assert!(created.is_ok());
+                assert!(Path::new(project_name).exists());
+                assert!(Path::new(&format!("{}/{}", project_name, CHAINSIGHT_FILENAME)).exists());
+                assert!(
+                    Path::new(&format!("{}/{}", project_name, PROJECT_MANIFEST_FILENAME)).exists()
+                );
+                assert!(Path::new(&format!("{}/{}", project_name, GITIGNORE_FILENAME)).exists());
+                assert!(Path::new(&format!("{}/components", project_name))
+                    .read_dir()
+                    .unwrap()
+                    .next()
+                    .is_none());
             },
             || {
                 teardown(project_name);

--- a/src/lib/codegen/bindings.rs
+++ b/src/lib/codegen/bindings.rs
@@ -14,7 +14,7 @@ use super::{
 
 pub fn generate_rs_bindings(
     root: &str,
-    component: &Box<dyn ComponentManifest>,
+    component: &dyn ComponentManifest,
 ) -> anyhow::Result<String> {
     let label = &component.metadata().label;
     let candid_path = &format!("{}/{}.did", &canisters_path_str(root, label), label);
@@ -37,13 +37,9 @@ fn create_candid_rust_binding(path: &Path) -> anyhow::Result<String> {
     Ok(result.to_string())
 }
 
-fn generate_default_query_call(component: &Box<dyn ComponentManifest>) -> Option<String> {
-    if component.default_query_identifier().is_none() {
-        return Option::None;
-    };
+fn generate_default_query_call(component: &dyn ComponentManifest) -> Option<String> {
     let method_identifier =
-        &CanisterMethodIdentifier::parse_from_str(component.default_query_identifier().unwrap())
-            .unwrap();
+        &CanisterMethodIdentifier::parse_from_str(component.default_query_identifier()?).unwrap();
     let func_to_call = &method_identifier.identifier.to_string();
     let proxy_func_to_call = "proxy_".to_string() + func_to_call;
     let method_label = &component.metadata().label;

--- a/src/lib/codegen/bindings.rs
+++ b/src/lib/codegen/bindings.rs
@@ -1,0 +1,95 @@
+use std::path::Path;
+
+use candid::pretty_check_file;
+use proc_macro2::Ident;
+use quote::{format_ident, quote};
+use regex::Regex;
+
+use crate::lib::utils::paths::canisters_path_str;
+
+use super::{
+    canisters::common::{CanisterMethodIdentifier, CanisterMethodValueType},
+    components::common::ComponentManifest,
+};
+
+pub fn generate_rs_bindings(
+    root: &str,
+    component: &Box<dyn ComponentManifest>,
+) -> anyhow::Result<String> {
+    let label = &component.metadata().label;
+    let candid_path = &format!("{}/{}.did", &canisters_path_str(root, label), label);
+    let bindings = create_candid_rust_binding(Path::new(candid_path))?;
+
+    if let Some(query) = generate_default_query_call(component) {
+        return Ok(format!("{}\n\n{}", bindings, query));
+    }
+    Ok(bindings)
+}
+
+fn create_candid_rust_binding(path: &Path) -> anyhow::Result<String> {
+    let (env, _) = pretty_check_file(path)?;
+    let config = candid::bindings::rust::Config::new();
+    let result = candid::bindings::rust::compile(&config, &env, &None)
+        .replace("use ic_cdk::api::call::CallResult as Result;", "")
+        .replace("pub enum Result", "enum Result");
+    let re = Regex::new(r"[^{](\w+): ").unwrap();
+    let result = re.replace_all(&result, " pub ${1}: ");
+    Ok(result.to_string())
+}
+
+fn generate_default_query_call(component: &Box<dyn ComponentManifest>) -> Option<String> {
+    if component.default_query_identifier().is_none() {
+        return Option::None;
+    };
+    let method_identifier =
+        &CanisterMethodIdentifier::parse_from_str(component.default_query_identifier().unwrap())
+            .unwrap();
+    let func_to_call = &method_identifier.identifier.to_string();
+    let proxy_func_to_call = "proxy_".to_string() + func_to_call;
+    let method_label = &component.metadata().label;
+    let method_args = method_identifier
+        .params
+        .iter()
+        .map(|arg| format_ident!("{}", arg))
+        .collect::<Vec<Ident>>();
+
+    let method_return_type = match &method_identifier.return_value {
+        CanisterMethodValueType::Scalar(ty, is_scalar) => match is_scalar {
+            true => format_ident!("{}", ty.to_string()),
+            false => format_ident!("{}", ty.to_string()),
+        },
+        _ => format_ident!("{}", "TODO".to_string()), // TODO: support tuple & struct
+    };
+
+    let import_macro = quote! {
+        use chainsight_cdk::lens::LensFinder;
+        use chainsight_cdk_macros::algorithm_lens_finder;
+
+        async fn _get_target_proxy(target: candid::Principal) -> candid::Principal {
+            let out: ic_cdk::api::call::CallResult<(candid::Principal,)> = ic_cdk::api::call::call(target, "get_proxy", ()).await;
+            out.unwrap().0
+        }
+    };
+
+    let ident = if method_args.is_empty() {
+        quote! {
+            #import_macro
+            algorithm_lens_finder!(
+                #method_label,
+                #proxy_func_to_call,
+                #method_return_type
+            );
+        }
+    } else {
+        quote! {
+            #import_macro
+            algorithm_lens_finder!(
+                #method_label,
+                #proxy_func_to_call,
+                #method_return_type,
+                #(#method_args),*
+            );
+        }
+    };
+    Option::Some(ident.to_string())
+}

--- a/src/lib/codegen/canisters/common.rs
+++ b/src/lib/codegen/canisters/common.rs
@@ -95,7 +95,11 @@ pub enum CanisterMethodValueType {
 }
 impl CanisterMethodIdentifier {
     pub fn parse_from_str(s: &str) -> anyhow::Result<Self> {
-        let captures = REGEX_CANDID_FUNC.captures(s).unwrap();
+        let captures = REGEX_CANDID_FUNC.captures(s).ok_or(anyhow::anyhow!(
+            "method.identifier does not satisfy the supported expression: {}, supplied={}",
+            REGEX_CANDID_FUNC.to_string(),
+            s
+        ))?;
 
         let identifier = captures.name("identifier").unwrap().as_str().to_string();
 

--- a/src/lib/codegen/canisters/event_indexer.rs
+++ b/src/lib/codegen/canisters/event_indexer.rs
@@ -69,7 +69,9 @@ fn custom_codes(
     let contract_struct_ident = format_ident!("{}", event_interface.trim_end_matches(".json")); // temp: specify the extension (only .json?)
     let abi_path = format!("./__interfaces/{}", event_interface);
 
-    let events = interface_contract.events_by_name(&datasource_event_def.identifier)?;
+    let events = interface_contract
+        .events_by_name(&datasource_event_def.identifier)
+        .map_err(|err| anyhow::anyhow!("failed to resolve event: {}", err))?;
     ensure!(
         events.len() == 1,
         "event is not found or there are multiple events"

--- a/src/lib/codegen/canisters/relayer.rs
+++ b/src/lib/codegen/canisters/relayer.rs
@@ -39,6 +39,7 @@ fn custom_codes(manifest: &RelayerComponentManifest) -> anyhow::Result<proc_macr
     let method = &manifest.datasource.method;
     let method_identifier = CanisterMethodIdentifier::parse_from_str(&method.identifier)?;
 
+    let label_ident = format_ident!("{}", &manifest.metadata.label);
     let method_ident = "proxy_".to_string() + &method_identifier.identifier;
 
     // from destination: about oracle
@@ -59,14 +60,13 @@ fn custom_codes(manifest: &RelayerComponentManifest) -> anyhow::Result<proc_macr
 
     // for response type
     let response_type: CanisterMethodValueType = method_identifier.return_value;
-    let (call_canister_response_type_ident, response_type_def_ident, sync_data_ident) =
-        generate_idents_to_call_datasource_and_sync_to_oracle(response_type, destination.type_)?;
+    let sync_data_ident = generate_ident_sync_to_oracle(response_type, destination.type_)?;
     let args_type_ident = match manifest.lens_targets.is_some() {
         true => quote! {
             type CallCanisterArgs = Vec<String>;
         },
         false => quote! {
-            type CallCanisterArgs = app::CallCanisterArgs;
+            type CallCanisterArgs = #label_ident::CallCanisterArgs;
         },
     };
     let lens_targets: Vec<Principal> = manifest
@@ -92,7 +92,7 @@ fn custom_codes(manifest: &RelayerComponentManifest) -> anyhow::Result<proc_macr
         },
         false => quote! {
             pub fn call_args() -> CallCanisterArgs {
-                app::call_args()
+                #label_ident::call_args()
             }
         },
     };
@@ -108,10 +108,8 @@ fn custom_codes(manifest: &RelayerComponentManifest) -> anyhow::Result<proc_macr
 
     Ok(quote! {
         ic_solidity_bindgen::contract_abi!(#abi_path);
+        use #label_ident::*;
         #relayer_source_ident
-        #response_type_def_ident
-        #call_canister_response_type_ident
-        mod app;
         #args_type_ident
         #get_args_ident
 
@@ -131,7 +129,7 @@ fn custom_codes(manifest: &RelayerComponentManifest) -> anyhow::Result<proc_macr
                 return;
             }
             let datum = val.unwrap();
-            if !app::filter(&datum) {
+            if !filter(&datum) {
                 return;
             }
 
@@ -146,95 +144,44 @@ fn custom_codes(manifest: &RelayerComponentManifest) -> anyhow::Result<proc_macr
     })
 }
 
-fn generate_idents_to_call_datasource_and_sync_to_oracle(
+fn generate_ident_sync_to_oracle(
     canister_response_type: CanisterMethodValueType,
     oracle_type: DestinationType,
-) -> anyhow::Result<(
-    proc_macro2::TokenStream, // call_canister_response_type_ident
-    proc_macro2::TokenStream, // response_type_def_ident
-    proc_macro2::TokenStream, // sync_data_ident
-)> {
+) -> anyhow::Result<proc_macro2::TokenStream> {
     let res = match canister_response_type {
         CanisterMethodValueType::Scalar(ty, _) => {
-            let ty_ident = format_ident!("{}", ty);
-            let call_canister_response_type_ident =
-                quote! { pub type CallCanisterResponse = #ty_ident; };
             let arg_ident = format_ident!("datum");
             match oracle_type {
                 DestinationType::Uint256Oracle => {
                     let quote_to_convert_datum_to_u256 =
                         generate_quote_to_convert_datum_to_u256(arg_ident, &ty)?;
-                    (
-                        call_canister_response_type_ident,
-                        quote! {},
-                        quote_to_convert_datum_to_u256,
-                    )
+                    quote_to_convert_datum_to_u256
                 }
                 DestinationType::Uint128Oracle => {
                     let quote_to_convert_datum =
                         generate_quote_to_convert_datum_to_integer(arg_ident, &ty, "u128")?;
-                    (
-                        call_canister_response_type_ident,
-                        quote! {},
-                        quote_to_convert_datum,
-                    )
+                    quote_to_convert_datum
                 }
                 DestinationType::Uint64Oracle => {
                     let quote_to_convert_datum =
                         generate_quote_to_convert_datum_to_integer(arg_ident, &ty, "u64")?;
-                    (
-                        call_canister_response_type_ident,
-                        quote! {},
-                        quote_to_convert_datum,
-                    )
+                    quote_to_convert_datum
                 }
-                DestinationType::StringOracle => (
-                    call_canister_response_type_ident,
-                    quote! {},
-                    quote! { datum.clone().to_string() },
-                ),
+                DestinationType::StringOracle => quote! { datum.clone().to_string() },
             }
         }
-        CanisterMethodValueType::Tuple(tys) => {
+        CanisterMethodValueType::Tuple(_) => {
             match oracle_type {
                 DestinationType::StringOracle => {
-                    let type_idents = tys
-                        .iter()
-                        .map(|(ty, _)| format_ident!("{}", ty))
-                        .collect::<Vec<proc_macro2::Ident>>();
-                    (
-                        quote! { type CallCanisterResponse = (#(#type_idents),*); },
-                        quote! {},
-                        quote! { format!("{:?}", &datum) }, // temp
-                    )
+                    quote! { format!("{:?}", &datum) } // temp
                 }
                 _ => bail!("not support tuple type for oracle"),
             }
         }
-        CanisterMethodValueType::Struct(values) => {
+        CanisterMethodValueType::Struct(_) => {
             match oracle_type {
                 DestinationType::StringOracle => {
-                    let response_type_def_ident = format_ident!("{}", "CustomResponseStruct");
-                    let struct_tokens = values
-                        .into_iter()
-                        .map(|(key, ty, _)| {
-                            let key_ident = format_ident!("{}", key);
-                            let ty_ident = format_ident!("{}", ty);
-                            quote! {
-                                pub #key_ident: #ty_ident
-                            }
-                        })
-                        .collect::<Vec<_>>();
-                    (
-                        quote! { type CallCanisterResponse = #response_type_def_ident; },
-                        quote! {
-                            #[derive(Clone, Debug, candid::CandidType, candid::Deserialize)]
-                            pub struct #response_type_def_ident {
-                                #(#struct_tokens),*
-                            }
-                        },
-                        quote! { format!("{:?}", &datum) }, // temp
-                    )
+                    quote! { format!("{:?}", &datum) } // temp
                 }
                 _ => bail!("not support struct type for oracle"),
             }

--- a/src/lib/codegen/canisters/relayer.rs
+++ b/src/lib/codegen/canisters/relayer.rs
@@ -153,19 +153,13 @@ fn generate_ident_sync_to_oracle(
             let arg_ident = format_ident!("datum");
             match oracle_type {
                 DestinationType::Uint256Oracle => {
-                    let quote_to_convert_datum_to_u256 =
-                        generate_quote_to_convert_datum_to_u256(arg_ident, &ty)?;
-                    quote_to_convert_datum_to_u256
+                    generate_quote_to_convert_datum_to_u256(arg_ident, &ty)?
                 }
                 DestinationType::Uint128Oracle => {
-                    let quote_to_convert_datum =
-                        generate_quote_to_convert_datum_to_integer(arg_ident, &ty, "u128")?;
-                    quote_to_convert_datum
+                    generate_quote_to_convert_datum_to_integer(arg_ident, &ty, "u128")?
                 }
                 DestinationType::Uint64Oracle => {
-                    let quote_to_convert_datum =
-                        generate_quote_to_convert_datum_to_integer(arg_ident, &ty, "u64")?;
-                    quote_to_convert_datum
+                    generate_quote_to_convert_datum_to_integer(arg_ident, &ty, "u64")?
                 }
                 DestinationType::StringOracle => quote! { datum.clone().to_string() },
             }

--- a/src/lib/codegen/canisters/snapshot_indexer.rs
+++ b/src/lib/codegen/canisters/snapshot_indexer.rs
@@ -226,6 +226,7 @@ fn custom_codes_for_canister(
     let method = &manifest.datasource.method;
     let method_identifier = CanisterMethodIdentifier::parse_from_str(&method.identifier)?;
 
+    let label_ident = format_ident!("{}", label);
     let method_ident = "proxy_".to_string() + &method_identifier.identifier; // NOTE: to call through proxy
 
     // for request values
@@ -328,7 +329,7 @@ fn custom_codes_for_canister(
             type CallCanisterArgs = Vec<String>;
         },
         false => quote! {
-            type CallCanisterArgs = app::CallCanisterArgs;
+            type CallCanisterArgs = #label_ident::CallCanisterArgs;
         },
     };
     let lens_targets: Vec<Principal> = manifest
@@ -354,7 +355,7 @@ fn custom_codes_for_canister(
         },
         false => quote! {
             pub fn call_args() -> CallCanisterArgs {
-                app::call_args()
+                #label_ident::call_args()
             }
         },
     };
@@ -371,7 +372,6 @@ fn custom_codes_for_canister(
         snapshot_icp_source!(#method_ident);
 
         //type CallCanisterArgs = (#(#request_ty_idents),*); TODO
-        mod app;
         type CallCanisterResponse = SnapshotValue;
         async fn execute_task() {
             #expr_to_current_ts_sec

--- a/src/lib/codegen/canisters/snapshot_indexer.rs
+++ b/src/lib/codegen/canisters/snapshot_indexer.rs
@@ -59,7 +59,7 @@ fn custom_codes_for_contract(
     // for request values
     ensure!(
         method_identifier.params.len() == method.args.len(),
-        "The number of params and args must be the same"
+        "datatource.method is not valid: The number of params in 'identifier' and 'args' must be the same"
     );
     let method_args = method
         .args
@@ -74,7 +74,7 @@ fn custom_codes_for_contract(
     let mut response_val_idents: Vec<proc_macro2::TokenStream> = vec![];
     let response_types = method_identifier.return_value;
     match response_types.len() {
-        0 => bail!("The number of response types must be greater than 0"),
+        0 => bail!("datatource.method.identifier is not valid: Response required"),
         1 => {
             // If it's a single type, we process it like we did before
             let ty = syn::parse_str::<syn::Type>(&response_types[0])?;

--- a/src/lib/codegen/canisters/snapshot_indexer_https.rs
+++ b/src/lib/codegen/canisters/snapshot_indexer_https.rs
@@ -14,6 +14,8 @@ pub fn generate_codes(
     let query_keys: Vec<&String> = manifest.datasource.queries.keys().collect();
     let query_values: Vec<&String> = manifest.datasource.queries.values().collect();
     let queries = generate_queries_without_timestamp(format_ident!("SnapshotValue"));
+
+    let label_ident = format_ident!("{}", label);
     let out = quote! {
         use chainsight_cdk::web2::{JsonRpcSnapshotParam, Web2JsonRpcSnapshotIndexer};
         use chainsight_cdk_macros::{
@@ -24,8 +26,7 @@ pub fn generate_codes(
 
         init_in!();
         chainsight_common!(60);
-        mod app;
-        use app::*;
+        use #label_ident::*;
         #[derive(Debug, Clone, candid::CandidType, candid::Deserialize, serde::Serialize, StableMemoryStorable)]
         #[stable_mem_storable_opts(max_size = 10000, is_fixed_size = false)] // temp: max_size
         pub struct Snapshot {

--- a/src/lib/codegen/components/algorithm_indexer.rs
+++ b/src/lib/codegen/components/algorithm_indexer.rs
@@ -205,7 +205,7 @@ mod tests {
         let yaml = r#"
 version: v1
 metadata:
-    label: sample_pj_algorithm_indexer
+    label: sample_algorithm_indexer
     type: algorithm_indexer
     description: Description
     tags: 
@@ -246,7 +246,7 @@ interval: 3600
             AlgorithmIndexerComponentManifest {
                 version: "v1".to_string(),
                 metadata: ComponentMetadata {
-                    label: "sample_pj_algorithm_indexer".to_string(),
+                    label: "sample_algorithm_indexer".to_string(),
                     type_: ComponentType::AlgorithmIndexer,
                     description: "Description".to_string(),
                     tags: Some(vec!["Ethereum".to_string(), "Account".to_string()])

--- a/src/lib/codegen/components/algorithm_lens.rs
+++ b/src/lib/codegen/components/algorithm_lens.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, fs::OpenOptions, io::Read, path::Path};
 
 use candid::{pretty_check_file, Principal};
 use proc_macro2::TokenStream;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -142,7 +143,9 @@ fn create_candid_rust_binding(path: &Path) -> anyhow::Result<String> {
     let result = candid::bindings::rust::compile(&config, &env, &None)
         .replace("use ic_cdk::api::call::CallResult as Result;", "")
         .replace("pub enum Result", "enum Result");
-    Ok(result)
+    let re = Regex::new(r"[^{](\w+): ").unwrap();
+    let result = re.replace_all(&result, " pub ${1}: ");
+    Ok(result.to_string())
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]

--- a/src/lib/codegen/components/algorithm_lens.rs
+++ b/src/lib/codegen/components/algorithm_lens.rs
@@ -163,7 +163,7 @@ impl Default for AlgorithmLensDataSource {
     fn default() -> Self {
         Self {
             methods: vec![AlgorithmLensDataSourceMethod {
-                label: "sample_snapshot_icp".to_string(),
+                label: "sample_snapshot_indexer_icp".to_string(),
                 identifier: "get_last_snapshot_value : () -> (SnapshotValue)".to_string(),
                 candid_file_path: "interfaces/sample.did".to_string(),
             }],
@@ -182,7 +182,7 @@ mod tests {
         let yaml = r#"
 version: v1
 metadata:
-    label: sample_pj_algorithm_lens
+    label: sample_algorithm_lens
     type: algorithm_lens
     description: Description
     tags: 
@@ -212,7 +212,7 @@ output:
             AlgorithmLensComponentManifest {
                 version: "v1".to_string(),
                 metadata: ComponentMetadata {
-                    label: "sample_pj_algorithm_lens".to_string(),
+                    label: "sample_algorithm_lens".to_string(),
                     type_: ComponentType::AlgorithmLens,
                     description: "Description".to_string(),
                     tags: Some(vec!["Ethereum".to_string(), "Account".to_string()])

--- a/src/lib/codegen/components/common.rs
+++ b/src/lib/codegen/components/common.rs
@@ -166,7 +166,7 @@ impl DatasourceLocation {
 
     pub fn default_canister() -> Self {
         Self::new_canister(
-            "sample_pj_snapshot_chain".to_string(),
+            "sample_snapshot_indexer_chain".to_string(),
             CanisterIdType::CanisterName,
         )
     }

--- a/src/lib/codegen/components/common.rs
+++ b/src/lib/codegen/components/common.rs
@@ -235,9 +235,11 @@ pub trait ComponentManifest: std::fmt::Debug {
     fn user_impl_required(&self) -> bool;
     fn generate_user_impl_template(&self) -> anyhow::Result<TokenStream>;
     fn get_sources(&self) -> Sources;
-    // map of file_name and additioal file content
-    fn additional_files(&self, _project_root: &Path) -> HashMap<String, String> {
-        HashMap::new()
+    fn default_query_identifier(&self) -> Option<&str> {
+        Option::None
+    }
+    fn dependencies(&self) -> Vec<String> {
+        vec![]
     }
 }
 

--- a/src/lib/codegen/components/event_indexer.rs
+++ b/src/lib/codegen/components/event_indexer.rs
@@ -213,7 +213,7 @@ mod tests {
         let yaml = r#"
 version: v1
 metadata:
-    label: sample_pj_event_indexer
+    label: sample_event_indexer
     type: event_indexer
     description: Description
     tags:
@@ -241,7 +241,7 @@ interval: 3600
             EventIndexerComponentManifest {
                 version: "v1".to_string(),
                 metadata: ComponentMetadata {
-                    label: "sample_pj_event_indexer".to_string(),
+                    label: "sample_event_indexer".to_string(),
                     type_: ComponentType::EventIndexer,
                     description: "Description".to_string(),
                     tags: Some(vec![

--- a/src/lib/codegen/components/relayer.rs
+++ b/src/lib/codegen/components/relayer.rs
@@ -264,7 +264,7 @@ mod tests {
         let yaml = r#"
 version: v1
 metadata:
-    label: sample_pj_relayer
+    label: sample_relayer
     type: relayer
     description: Description
     tags:
@@ -296,7 +296,7 @@ interval: 3600
             RelayerComponentManifest {
                 version: "v1".to_string(),
                 metadata: ComponentMetadata {
-                    label: "sample_pj_relayer".to_string(),
+                    label: "sample_relayer".to_string(),
                     type_: ComponentType::Relayer,
                     description: "Description".to_string(),
                     tags: Some(vec!["Oracle".to_string(), "snapshot".to_string()])

--- a/src/lib/codegen/components/relayer.rs
+++ b/src/lib/codegen/components/relayer.rs
@@ -1,14 +1,19 @@
 use std::{collections::HashMap, fs::OpenOptions, io::Read, path::Path};
 
-use anyhow::Ok;
+use anyhow::{bail, Ok};
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{format_ident, quote};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::{
     lib::codegen::{
-        canisters, components::common::custom_tags_interval_sec, oracle::get_oracle_address,
+        canisters::{
+            self,
+            common::{CanisterMethodIdentifier, CanisterMethodValueType},
+        },
+        components::common::custom_tags_interval_sec,
+        oracle::get_oracle_address,
         scripts,
     },
     types::{ComponentType, Network},
@@ -116,6 +121,51 @@ impl ComponentManifest for RelayerComponentManifest {
         }
     }
     fn generate_user_impl_template(&self) -> anyhow::Result<TokenStream> {
+        let response_type =
+            CanisterMethodIdentifier::parse_from_str(&self.datasource.method.identifier)?
+                .return_value;
+        let oracle_type = &self.destination.type_;
+
+        let response_type_ident = match response_type {
+            CanisterMethodValueType::Scalar(ty, _) => {
+                let ty_ident = format_ident!("{}", ty);
+                quote! { pub type CallCanisterResponse = #ty_ident }
+            }
+            CanisterMethodValueType::Tuple(tys) => match oracle_type {
+                DestinationType::StringOracle => {
+                    let type_idents = tys
+                        .iter()
+                        .map(|(ty, _)| format_ident!("{}", ty))
+                        .collect::<Vec<proc_macro2::Ident>>();
+                    quote! { pub type CallCanisterResponse = (#(#type_idents),*) }
+                }
+                _ => bail!("not support tuple type for oracle"),
+            },
+            CanisterMethodValueType::Struct(values) => match oracle_type {
+                DestinationType::StringOracle => {
+                    let response_type_def_ident = format_ident!("{}", "CustomResponseStruct");
+                    let struct_tokens = values
+                        .into_iter()
+                        .map(|(key, ty, _)| {
+                            let key_ident = format_ident!("{}", key);
+                            let ty_ident = format_ident!("{}", ty);
+                            quote! {
+                                pub #key_ident: #ty_ident
+                            }
+                        })
+                        .collect::<Vec<_>>();
+                    quote! {
+                    pub type CallCanisterResponse = #response_type_def_ident;
+                       #[derive(Clone, Debug, candid::CandidType, candid::Deserialize)]
+                       pub struct #response_type_def_ident {
+                           #(#struct_tokens),*
+                       }
+                    }
+                }
+                _ => bail!("not support struct type for oracle"),
+            },
+        };
+
         let args_quote = match self.lens_targets.is_some() {
             true => quote! {},
             false => quote! {
@@ -126,7 +176,7 @@ impl ComponentManifest for RelayerComponentManifest {
             },
         };
         Ok(quote! {
-            use crate::{CallCanisterResponse};
+            #response_type_ident;
             #args_quote
             pub fn filter(_: &CallCanisterResponse) -> bool {
                 true

--- a/src/lib/codegen/components/snapshot_indexer.rs
+++ b/src/lib/codegen/components/snapshot_indexer.rs
@@ -183,7 +183,7 @@ mod tests {
         let yaml = r#"
 version: v1
 metadata:
-    label: sample_pj_snapshot_chain
+    label: sample_snapshot_indexer_chain
     type: snapshot_indexer
     description: Description
     tags:
@@ -213,7 +213,7 @@ interval: 3600
             SnapshotIndexerComponentManifest {
                 version: "v1".to_owned(),
                 metadata: ComponentMetadata {
-                    label: "sample_pj_snapshot_chain".to_owned(),
+                    label: "sample_snapshot_indexer_chain".to_owned(),
                     type_: ComponentType::SnapshotIndexer,
                     description: "Description".to_string(),
                     tags: Some(vec!["ERC-20".to_string(), "Ethereum".to_string()])
@@ -245,7 +245,7 @@ interval: 3600
         let yaml = r#"
 version: v1
 metadata:
-    label: sample_pj_snapshot_icp
+    label: sample_snapshot_indexer_icp
     type: snapshot_indexer
     description: Description
     tags:
@@ -273,7 +273,7 @@ interval: 3600
             SnapshotIndexerComponentManifest {
                 version: "v1".to_owned(),
                 metadata: ComponentMetadata {
-                    label: "sample_pj_snapshot_icp".to_owned(),
+                    label: "sample_snapshot_indexer_icp".to_owned(),
                     type_: ComponentType::SnapshotIndexer,
                     description: "Description".to_string(),
                     tags: Some(vec!["ERC-20".to_string(), "Ethereum".to_string()])

--- a/src/lib/codegen/components/snapshot_indexer.rs
+++ b/src/lib/codegen/components/snapshot_indexer.rs
@@ -142,6 +142,9 @@ impl ComponentManifest for SnapshotIndexerComponentManifest {
             attributes: attr,
         }
     }
+    fn default_query_identifier(&self) -> Option<&str> {
+        Option::Some("get_last_snapshot_value : () -> (text)")
+    }
     fn custom_tags(&self) -> HashMap<String, String> {
         let mut res = HashMap::new();
         let (interval_key, interval_val) = custom_tags_interval_sec(self.interval);

--- a/src/lib/codegen/components/snapshot_indexer_https.rs
+++ b/src/lib/codegen/components/snapshot_indexer_https.rs
@@ -129,6 +129,7 @@ impl ComponentManifest for SnapshotIndexerHTTPSComponentManifest {
             use chainsight_cdk_macros::StableMemoryStorable;
             #[derive(Debug, Clone, candid::CandidType, candid::Deserialize, serde::Serialize, StableMemoryStorable)]
             pub struct SnapshotValue {
+               pub dummy: u64
             }
         };
         Ok(v)
@@ -139,6 +140,9 @@ impl ComponentManifest for SnapshotIndexerHTTPSComponentManifest {
             source_type: SourceType::Https,
             attributes: HashMap::new(),
         }
+    }
+    fn default_query_identifier(&self) -> Option<&str> {
+        Option::Some("get_last_snapshot_value : () -> (SnapshotValue)")
     }
     fn custom_tags(&self) -> HashMap<String, String> {
         let mut res = HashMap::new();

--- a/src/lib/codegen/components/snapshot_indexer_https.rs
+++ b/src/lib/codegen/components/snapshot_indexer_https.rs
@@ -164,7 +164,7 @@ mod tests {
         let yaml = r#"
 version: v1
 metadata:
-    label: sample_pj_snapshot_indexer_https
+    label: sample_snapshot_indexer_https
     type: snapshot_indexer_https
     description: Description
     tags:
@@ -191,7 +191,7 @@ interval: 3600
             SnapshotIndexerHTTPSComponentManifest {
                 version: "v1".to_owned(),
                 metadata: ComponentMetadata {
-                    label: "sample_pj_snapshot_indexer_https".to_owned(),
+                    label: "sample_snapshot_indexer_https".to_owned(),
                     type_: ComponentType::SnapshotIndexerHTTPS,
                     description: "Description".to_string(),
                     tags: Some(vec![

--- a/src/lib/codegen/mod.rs
+++ b/src/lib/codegen/mod.rs
@@ -1,5 +1,7 @@
+pub mod bindings;
 pub mod canisters;
 pub mod components;
 pub mod oracle;
 pub mod project;
 pub mod scripts;
+pub mod templates;

--- a/src/lib/codegen/templates.rs
+++ b/src/lib/codegen/templates.rs
@@ -1,8 +1,7 @@
 use crate::lib::utils::paths;
 
 pub fn root_cargo_toml() -> String {
-    format!(
-        r#"[workspace]
+    r#"[workspace]
 members = ["bindings/*", "canisters/*", "logics/*"]
 
 [workspace.dependencies]
@@ -15,12 +14,11 @@ serde = "1.0.163"
 serde_bytes = "0.11.12"
 hex = "0.4.3"
 
-ic-web3-rs = {{ version = "0.1.1" }}
-ic-solidity-bindgen = {{ version = "0.1.5" }}
-chainsight-cdk-macros = {{ git = "https://github.com/horizonx-tech/chainsight-sdk.git", rev = "7fdf04d636c11ab7796fefc40d0e9ee92a3183fa" }}
-chainsight-cdk = {{ git = "https://github.com/horizonx-tech/chainsight-sdk.git", rev = "7fdf04d636c11ab7796fefc40d0e9ee92a3183fa" }}
-"#
-    )
+ic-web3-rs = { version = "0.1.1" }
+ic-solidity-bindgen = { version = "0.1.5" }
+chainsight-cdk-macros = { git = "https://github.com/horizonx-tech/chainsight-sdk.git", rev = "7fdf04d636c11ab7796fefc40d0e9ee92a3183fa" }
+chainsight-cdk = { git = "https://github.com/horizonx-tech/chainsight-sdk.git", rev = "7fdf04d636c11ab7796fefc40d0e9ee92a3183fa" }
+"#.to_string()
 }
 
 pub fn logic_cargo_toml(project_name: &str, dependencies: Vec<String>) -> String {

--- a/src/lib/codegen/templates.rs
+++ b/src/lib/codegen/templates.rs
@@ -159,3 +159,13 @@ pub fn dfx_json(project_labels: Vec<String>) -> String {
 
     result
 }
+
+pub fn gitignore() -> String {
+    r#"src/__interfaces
+src/bindings
+src/canisters
+src/target
+artifacts
+"#
+    .to_string()
+}

--- a/src/lib/codegen/templates.rs
+++ b/src/lib/codegen/templates.rs
@@ -1,0 +1,161 @@
+use crate::lib::utils::paths;
+
+pub fn root_cargo_toml() -> String {
+    format!(
+        r#"[workspace]
+members = ["bindings/*", "canisters/*", "logics/*"]
+
+[workspace.dependencies]
+candid = "0.8"
+ic-cdk = "0.8"
+ic-cdk-macros = "0.6.10"
+ic-cdk-timers = "0.1"
+ic-stable-structures = "0.5.5"
+serde = "1.0.163"
+serde_bytes = "0.11.12"
+hex = "0.4.3"
+
+ic-web3-rs = {{ version = "0.1.1" }}
+ic-solidity-bindgen = {{ version = "0.1.5" }}
+chainsight-cdk-macros = {{ git = "https://github.com/horizonx-tech/chainsight-sdk.git", rev = "7fdf04d636c11ab7796fefc40d0e9ee92a3183fa" }}
+chainsight-cdk = {{ git = "https://github.com/horizonx-tech/chainsight-sdk.git", rev = "7fdf04d636c11ab7796fefc40d0e9ee92a3183fa" }}
+"#
+    )
+}
+
+pub fn logic_cargo_toml(project_name: &str, dependencies: Vec<String>) -> String {
+    let txt = format!(
+        r#"[package]
+name = "{}"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+candid.workspace = true
+ic-cdk.workspace = true
+ic-cdk-macros.workspace = true
+ic-cdk-timers.workspace = true
+ic-stable-structures.workspace = true
+serde.workspace = true
+serde_bytes.workspace = true
+hex.workspace = true
+
+ic-web3-rs.workspace = true
+ic-solidity-bindgen.workspace = true
+chainsight-cdk-macros.workspace = true
+chainsight-cdk.workspace = true
+
+{}
+"#,
+        project_name,
+        dependencies
+            .iter()
+            .map(|x| paths::bindings_dependency(x))
+            .collect::<Vec<String>>()
+            .join("\n")
+    );
+
+    txt
+}
+
+pub fn canister_project_cargo_toml(project_name: &str) -> String {
+    format!(
+        r#"[package]
+name = "{}"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+candid.workspace = true
+ic-cdk.workspace = true
+ic-cdk-macros.workspace = true
+ic-cdk-timers.workspace = true
+ic-stable-structures.workspace = true
+serde.workspace = true
+serde_bytes.workspace = true
+hex.workspace = true
+
+ic-web3-rs.workspace = true
+ic-solidity-bindgen.workspace = true
+chainsight-cdk-macros.workspace = true
+chainsight-cdk.workspace = true
+
+{}
+"#,
+        paths::canister_name(project_name),
+        paths::logic_dependency(project_name),
+    )
+}
+
+pub fn bindings_cargo_toml(component: &str) -> String {
+    format!(
+        r#"[package]
+name = "{}"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+candid.workspace = true
+ic-cdk.workspace = true
+serde.workspace = true
+serde_bytes.workspace = true
+
+chainsight-cdk-macros.workspace = true
+chainsight-cdk.workspace = true
+"#,
+        paths::bindings_name(component)
+    )
+}
+
+pub fn dfx_json(project_labels: Vec<String>) -> String {
+    let canisters = project_labels
+        .iter()
+        .map(|label| {
+            format!(
+                r#"      "{}": {{
+        "type": "custom",
+        "candid": "./{}.did",
+        "wasm": "./{}.wasm",
+        "metadata": [
+          {{
+            "name": "candid:service",
+            "visibility": "public"
+          }}
+        ]
+      }}
+"#,
+                label, label, label
+            )
+        })
+        .collect::<Vec<String>>()
+        .join(",\n");
+
+    let result = format!(
+        r#"{{
+  "version": 1,
+  "canisters": {{
+{}
+  }},
+  "defaults": {{
+    "build": {{
+      "packtool": "",
+      "args": ""
+    }}
+  }},
+  "output_env_file": ".env"
+}}
+"#,
+        canisters
+    );
+
+    result
+}

--- a/src/lib/utils/mod.rs
+++ b/src/lib/utils/mod.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use inflector::cases::snakecase::to_snake_case;
 
 pub mod clap;
+pub mod paths;
 
 pub const CHAINSIGHT_FILENAME: &str = ".chainsight";
 pub const PROJECT_MANIFEST_FILENAME: &str = "project.yaml";

--- a/src/lib/utils/mod.rs
+++ b/src/lib/utils/mod.rs
@@ -8,6 +8,7 @@ pub mod paths;
 pub const CHAINSIGHT_FILENAME: &str = ".chainsight";
 pub const PROJECT_MANIFEST_FILENAME: &str = "project.yaml";
 pub const PROJECT_MANIFEST_VERSION: &str = "v1";
+pub const GITIGNORE_FILENAME: &str = ".gitignore";
 pub const ARTIFACTS_DIR: &str = "artifacts";
 
 /// To handle 256bits Unsigned Integer type in ic_web3_rs

--- a/src/lib/utils/paths.rs
+++ b/src/lib/utils/paths.rs
@@ -1,0 +1,38 @@
+pub fn src_path_str(root: &str) -> String {
+    format!("{}/src", root)
+}
+
+pub fn logics_path_str(src: &str, component: &str) -> String {
+    format!("{}/logics/{}", src, component)
+}
+
+pub fn canisters_path_str(src: &str, component: &str) -> String {
+    format!("{}/canisters/{}", src, component)
+}
+
+pub fn bindings_path_str(src: &str, component: &str) -> String {
+    format!("{}/bindings/{}", src, bindings_name(component))
+}
+
+pub fn canister_name(component: &str) -> String {
+    format!("{}_canister", component)
+}
+
+pub fn bindings_name(component: &str) -> String {
+    format!("{}_bindings", component)
+}
+
+pub fn logic_dependency(component: &str) -> String {
+    format!(
+        r#"{} = {{ path = "../../logics/{}" }}"#,
+        component, component
+    )
+}
+
+pub fn bindings_dependency(component: &str) -> String {
+    format!(
+        r#"{} = {{ path = "../../bindings/{}" }}"#,
+        bindings_name(component),
+        bindings_name(component)
+    )
+}


### PR DESCRIPTION
1. Restructure packages to distinguish between:
A. those that should be managed by the user after initial generation
B. those that fully auto-generated (and should not be managed by git)

  ```
ROOT 
  ├ src
  │   ├ Cargo.toml ... A
  │   ├ logics     ... A
  │   ├ bindings   ... B
  │   └ canisters  ... B
  └ artifacts      ... B
```

2. Changes in  commands
   - `build --only-codegen` -> `generate` (alias: `gen`)
   - `build --only-build` -> `build`
   - `create` -> `add` (deprecated alias: `create`)
   - add `new --no-samples, -n`: Skip generation of samples 