### PR TITLE
separate accessors to other canisters

### DIFF
--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -41,9 +41,9 @@ pub fn exec<U: UserInteraction>(
     if interaction
         .confirm("Do you want to select components to delete? (If no, delete the entire project.)")
     {
-        remove_components(log, project_path_opt.clone(), interaction)?;
+        remove_components(log, project_path_opt, interaction)?;
     } else {
-        remove_project(log, project_path_opt.clone(), interaction)?;
+        remove_project(log, project_path_opt, interaction)?;
     }
 
     Ok(())
@@ -100,7 +100,7 @@ fn remove_components<U: UserInteraction>(
     project_path_opt: Option<String>,
     interaction: &mut U,
 ) -> anyhow::Result<()> {
-    let project_path_str = project_path_opt.clone().unwrap_or(".".to_string());
+    let project_path_str = project_path_opt.unwrap_or(".".to_string());
     let project_file_path = format!("{}/{}", project_path_str, PROJECT_MANIFEST_FILENAME);
     let mut project_manifest = ProjectManifestData::load(&project_file_path)?;
 

--- a/src/lib/codegen/canisters/algorithm_lens.rs
+++ b/src/lib/codegen/canisters/algorithm_lens.rs
@@ -77,7 +77,7 @@ pub fn generate_app(manifest: &AlgorithmLensComponentManifest) -> anyhow::Result
             },
             Err(error) => {
                 let message = error.to_string();
-                return quote! { todo!(#message); };
+                quote! { todo!(#message); }
             }
         }
     });

--- a/src/lib/codegen/components/algorithm_lens.rs
+++ b/src/lib/codegen/components/algorithm_lens.rs
@@ -101,6 +101,9 @@ impl ComponentManifest for AlgorithmLensComponentManifest {
             .map(|e| e.label.clone())
             .collect()
     }
+    fn generate_dependency_accessors(&self) -> anyhow::Result<TokenStream> {
+        canisters::algorithm_lens::generate_dependencies_accessor(self)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]

--- a/src/lib/codegen/components/common.rs
+++ b/src/lib/codegen/components/common.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, fs::OpenOptions, io::Read, path::Path};
 
+use anyhow::bail;
 use proc_macro2::TokenStream;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -252,6 +253,9 @@ pub trait ComponentManifest: std::fmt::Debug {
     /// NOTE: only used by alhorithm_lens
     fn dependencies(&self) -> Vec<String> {
         vec![]
+    }
+    fn generate_dependency_accessors(&self) -> anyhow::Result<TokenStream> {
+        bail!("not implemented")
     }
 }
 

--- a/src/lib/codegen/templates.rs
+++ b/src/lib/codegen/templates.rs
@@ -2,7 +2,7 @@ use crate::lib::utils::paths;
 
 pub fn root_cargo_toml() -> String {
     r#"[workspace]
-members = ["bindings/*", "canisters/*", "logics/*"]
+members = ["canisters/*"]
 
 [workspace.dependencies]
 candid = "0.8"
@@ -49,6 +49,44 @@ chainsight-cdk.workspace = true
 {}
 "#,
         project_name,
+        if dependencies.is_empty() {
+            "".to_string()
+        } else {
+            paths::accessors_dependency(project_name)
+        }
+    );
+
+    txt
+}
+
+pub fn accessors_cargo_toml(project_name: &str, dependencies: Vec<String>) -> String {
+    let txt = format!(
+        r#"[package]
+name = "{}"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+candid.workspace = true
+ic-cdk.workspace = true
+ic-cdk-macros.workspace = true
+ic-cdk-timers.workspace = true
+ic-stable-structures.workspace = true
+serde.workspace = true
+serde_bytes.workspace = true
+hex.workspace = true
+
+ic-web3-rs.workspace = true
+ic-solidity-bindgen.workspace = true
+chainsight-cdk-macros.workspace = true
+chainsight-cdk.workspace = true
+
+{}
+"#,
+        paths::accessors_name(project_name),
         dependencies
             .iter()
             .map(|x| paths::bindings_dependency(x))
@@ -160,6 +198,7 @@ pub fn dfx_json(project_labels: Vec<String>) -> String {
 
 pub fn gitignore() -> String {
     r#"src/__interfaces
+src/accessors
 src/bindings
 src/canisters
 src/target

--- a/src/lib/utils/mod.rs
+++ b/src/lib/utils/mod.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{panic, path::Path};
 
 use inflector::cases::snakecase::to_snake_case;
 
@@ -48,4 +48,14 @@ pub fn find_duplicates<T: Eq + std::hash::Hash>(values: &[T]) -> Vec<&T> {
         }
     }
     duplicates
+}
+
+pub fn catch_unwind_silent<F: FnOnce() -> R + panic::UnwindSafe, R>(
+    f: F,
+) -> std::thread::Result<R> {
+    let prev_hook = panic::take_hook();
+    panic::set_hook(Box::new(|_| {}));
+    let result = panic::catch_unwind(f);
+    panic::set_hook(prev_hook);
+    result
 }

--- a/src/lib/utils/paths.rs
+++ b/src/lib/utils/paths.rs
@@ -14,12 +14,19 @@ pub fn bindings_path_str(src: &str, component: &str) -> String {
     format!("{}/bindings/{}", src, bindings_name(component))
 }
 
+pub fn accessors_path_str(src: &str, component: &str) -> String {
+    format!("{}/accessors/{}", src, accessors_name(component))
+}
+
 pub fn canister_name(component: &str) -> String {
     format!("{}_canister", component)
 }
 
 pub fn bindings_name(component: &str) -> String {
     format!("{}_bindings", component)
+}
+pub fn accessors_name(component: &str) -> String {
+    format!("{}_accessors", component)
 }
 
 pub fn logic_dependency(component: &str) -> String {
@@ -34,5 +41,13 @@ pub fn bindings_dependency(component: &str) -> String {
         r#"{} = {{ path = "../../bindings/{}" }}"#,
         bindings_name(component),
         bindings_name(component)
+    )
+}
+
+pub fn accessors_dependency(component: &str) -> String {
+    format!(
+        r#"{} = {{ path = "../../accessors/{}" }}"#,
+        accessors_name(component),
+        accessors_name(component)
     )
 }


### PR DESCRIPTION
This allows boilerplate to be generated when dependencies are added.